### PR TITLE
Remove Test::WWW::Mechanize::PSGI

### DIFF
--- a/t/plugins2-2.t
+++ b/t/plugins2-2.t
@@ -1,22 +1,29 @@
 use strict;
 use warnings;
 
-use lib 't/lib';
-
-use poc2;
 use Test::More tests => 6;
+use Plack::Test;
+use HTTP::Request::Common;
 
-use Test::WWW::Mechanize::PSGI;
+use lib 't/lib';
+use poc2;
 
- my $mech = Test::WWW::Mechanize::PSGI->new(
-          app =>  poc2->to_app
-      );
+my $test = Plack::Test->create( poc2->to_app );
 
-$mech->get_ok( '/' );
-$mech->content_like( qr'please' );
-$mech->content_like( qr'8-D' );
+note "poc2 root"; {
+    my $res = $test->request( GET '/' );
+    ok $res->is_success;
 
-$mech->get_ok('/goodbye');
+    my $content = $res->content;
+    like $content, qr/please/;
+    like $content, qr/8-D/;
+}
 
-$mech->content_like( qr/farewell/ );
-$mech->content_like( qr'please' );
+note "pos2 goodbye"; {
+    my $res = $test->request( GET '/goodbye' );
+    ok $res->is_success;
+
+    my $content = $res->content;
+    like $content, qr/farewell/;
+    like $content, qr/please/;
+}

--- a/t/plugins2-hooks.t
+++ b/t/plugins2-hooks.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 
 use Test::More tests => 6;
+use Plack::Test;
+use HTTP::Request::Common;
 
 {  
     package Dancer2::Plugin::FooDetector;
@@ -48,16 +50,15 @@ use Test::More tests => 6;
 }
 
 
-use Test::WWW::Mechanize::PSGI;
+my $test = Plack::Test->create( PoC->to_app );
 
- my $mech = Test::WWW::Mechanize::PSGI->new(
-          app =>  PoC->to_app
-      );
+ok $test->request( GET '/meh' )->is_success;
+my $res = $test->request( GET '/hooked' );
+ok $res->is_success;
+is $res->content, 'nope';
 
-$mech->get_ok( '/meh' );
-$mech->get_ok( '/hooked' );
-$mech->content_is( 'nope' );
+ok $test->request( GET '/' )->is_success;
+$res = $test->request( GET '/hooked' );
+ok $res->is_success;
+is $res->content, 'hooked';
 
-$mech->get_ok( '/' );
-$mech->get_ok( '/hooked' );
-$mech->content_is( 'hooked' );


### PR DESCRIPTION
Rewrite the three test files that were using Test::WWW::Mechanize::PSGI
to use Plack::Test and HTTP::Request::Common. They were simple tests and
are now only slightly more verbose (one line here or there), but we save
adding a test dependency.
